### PR TITLE
Catching EPIPE error caused by `source` closing file descriptor before reading it

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -1,4 +1,3 @@
-
 var fs = require('fs'),
   path = require('path'),
   exec = require('child_process').exec;
@@ -41,7 +40,23 @@ exports.complete = function complete(name, completer, cb) {
   // if the COMP_* are not in the env, then dump the install script.
   if(!env.words || !env.point || !env.line) return script(name, completer, function(err, content) {
     if(err) return cb(err);
-    console.log(content);
+    process.stdout.write(content, function (n) { cb(null, null, content); });
+    process.stdout.on("error", function (er) {
+      // Darwin is a real dick sometimes.
+      //
+      // This is necessary because the "source" or "." program in
+      // bash on OS X closes its file argument before reading
+      // from it, meaning that you get exactly 1 write, which will
+      // work most of the time, and will always raise an EPIPE.
+      //
+      // Really, one should not be tossing away EPIPE errors, or any
+      // errors, so casually.  But, without this, `. <(npm completion)`
+      // can never ever work on OS X.
+      //      -- isaacs 
+      // https://github.com/isaacs/npm/blob/master/lib/completion.js#L162
+      if (er.errno === "EPIPE") er = null
+      cb(er, null, content);
+    });
     cb(null, null, content);
   });
 


### PR DESCRIPTION
Just added the same lines that isaacs has in completion.js to catch the EPIPE error caused by using console.log or process.stdout.write in a subshell used for process substitution.

Near as I can tell the only way to make this work on OS X is to ask the user to:

```
$ pkgname completion > /usr/local/etc/bash_completion.d/pkgname.bash
$ echo "source /usr/local/etc/bash_completion.d/pkgname.bash" >> .bashrc
```

I'm trying to find out if there is an alternate bash syntax for use in .bashrc that will keep the file descriptor open long enough to `source` from it.
