### PR TITLE
Allow completing long options

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -119,7 +119,7 @@ function cleanPrefix(s) {
 }
 
 function abbrev(o) { return function(it) {
-  return new RegExp('^' + o.last.replace(/^-/g, '')).test(it);
+  return new RegExp('^' + o.last.replace(/^--?/g, '')).test(it);
 }}
 
 // output the completion.sh script to the console for install instructions.


### PR DESCRIPTION
There was a bug where any string starting with '--' would never be
matched by tab completion.  This allows double dashed items to match
completions.
