### PR TITLE
changed obsolete path.exists() by fs.lstat()

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -195,18 +195,18 @@ function uninstall(name, completer, cb) {
 
 function readRc(completer, cb) {
   var file = '.' + process.env.SHELL.match(/\/bin\/(\w+)/)[1] + 'rc',
-    filepath = path.join(process.env.HOME, file);
-  path.exists(filepath, function (state) {
-    if(!state) return cb(new Error("No " + file + " file. You'll have to run instead: " + completer + " completion >> ~/" + file));
+  filepath = path.join(process.env.HOME, file);
+  fs.lstat(filepath, function (err, stats) {
+    if(err) return cb(new Error("No " + file + " file. You'll have to run instead: " + completer + " completion >> ~/" + file));
     fs.readFile(filepath, 'utf8', cb);
   });
 }
 
 function writeRc(content, cb) {
   var file = '.' + process.env.SHELL.match(/\/bin\/(\w+)/)[1] + 'rc',
-    filepath = path.join(process.env.HOME, file);
-  path.exists(filepath, function (state) {
-    if(!state) return cb(new Error("No " + file + " file. You'll have to run instead: " + completer + " completion >> ~/" + file));
+  filepath = path.join(process.env.HOME, file);
+  fs.lstat(filepath, function (err, stats) {
+    if(err) return cb(new Error("No " + file + " file. You'll have to run instead: " + completer + " completion >> ~/" + file));
     fs.writeFile(filepath, content, cb);
   });
 }


### PR DESCRIPTION
The path.exists() function used in the install command is no longer supported in the latest versions of node, changed it to fs.lstat() (recommended over fs.exists()).