### PR TITLE
zsh (on osx anyway) seems to require a space before the ]]

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -120,7 +120,7 @@ export default class Installer {
           if (this.template === 'fish') {
             out.write('\n[ -f ' + filename + ' ]; and . ' + filename);
           } else if (this.template === 'zsh') {
-            out.write('\n[[ -f ' + filename + ']] && . ' + filename);
+            out.write('\n[[ -f ' + filename + ' ]] && . ' + filename);
           } else {
             out.write('\n[ -f ' + filename + '] && . ' + filename);
           }


### PR DESCRIPTION
The install will cause an error when put into your ~/.zshrc on zsh 5.0.8 and 5.2 due to a lack of a space, this adds that space in.