### PR TITLE
fix(win32): fix usage of SHELL environment variable when it is not set

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -31,7 +31,7 @@ export default class Commands {
     this.options = options || {};
     this.complete = new Complete(this.options);
     this.installer = new Installer(this.options, this.complete);
-    this.shell = process.env.SHELL.split('/').slice(-1)[0];
+    this.shell = (process.env.SHELL || '').split('/').slice(-1)[0];
   }
 
   // Commands

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -26,7 +26,7 @@ export default class Installer {
     this.options = options || {};
     this.complete = complete;
 
-    this._shell = process.env.SHELL.split('/').slice(-1)[0];
+    this._shell = (process.env.SHELL || '').split('/').slice(-1)[0];
     this.dest = this._shell === 'zsh' ? 'zshrc' :
       this._shell === 'bash' ? 'bashrc' :
       'fish';


### PR DESCRIPTION
`process.env.SHELL` is not set on windows so this was throwing errors on `tabtab install --auto`